### PR TITLE
default.xml: Introduce manifest to build U-Boot

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,0 +1,39 @@
+<manifest>
+<contactinfo bugurl="go/repo-bug"/>
+<remote name="aosp" fetch="https://android.googlesource.com/" review="https://android.googlesource.com/"/>
+<remote name="github" fetch="ssh://git@github.com"/>
+<default revision="master" remote="aosp" sync-j="4"/>
+<superproject name="kernel/superproject" remote="aosp" revision="u-boot-mainline"/>
+<project path="bootable/libbootloader" name="platform/bootable/libbootloader" revision="ccf35bfd516301ce6efd95783a6c7bd4ca556e55"/>
+<project path="build/bazel_common_rules" name="platform/build/bazel_common_rules" revision="4e0aa41c4eda608ec715d704f8ab511e3dd10774"/>
+<project path="build/kernel" name="kernel/build" revision="62985f09053339f891c8f8cd2a1fc81e825d0a4e">
+<linkfile dest="build/build.sh" src="build.sh"/>
+<linkfile dest="build/build_utils.sh" src="build_utils.sh"/>
+<linkfile dest="build/_setup_env.sh" src="_setup_env.sh"/>
+<linkfile dest="tools/bazel" src="kleaf/bazel.sh"/>
+</project>
+<project path="external/arm-trusted-firmware" name="platform/external/arm-trusted-firmware" revision="bef081324a58c77ab585e337af6053ac6b6ff1c3"/>
+<project path="external/boringssl" name="platform/external/boringssl" revision="84f1dfe9bec6ffbebbdcb0af5225763479ce254c"/>
+<project path="external/compiler-rt" name="platform/external/compiler-rt" revision="b429e93fbf939d13875665f7666c36dde342371d"/>
+<project path="external/dtc" name="platform/external/dtc" revision="007e485e205e2d14b2ef1657021a37e95ee3a3d6"/>
+<project path="external/open-dice" name="platform/external/open-dice" revision="a873dcf0702b21c42838d04140ccf0a15ceae94d"/>
+<project path="external/bazel-skylib" name="platform/external/bazel-skylib" revision="f998e5dc13c03f0eae9e373263d3afff0932c738"/>
+<project path="external/stardoc" name="platform/external/stardoc" revision="398e266839a9d590a3c4fe4e9bc382bc2607a06e"/>
+<project path="external/swig" name="platform/external/swig" revision="0ffab894f917fcbbd031eaab870fbabaefe5daaa"/>
+<project path="external/zlib" name="platform/external/zlib" revision="4d02aae00087d32d4cd7e74c038d7256dc544fa9"/>
+<project path="u-boot" name="xen-troops/u-boot" remote="github" revision="xenvm-trout-main">
+<linkfile dest=".source_date_epoch_dir" src="."/>
+<linkfile dest="WORKSPACE" src="bazel.WORKSPACE"/>
+</project>
+<project path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" name="platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" clone-depth="1" revision="dfa84be8039e99afda2a9b31fc8bb6238d4f1c62"/>
+<project path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" name="platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9" clone-depth="1" revision="3b6581a8f1fca1a0a3bf9f91d9eede6de77e414c"/>
+<project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.17-4.8" clone-depth="1" revision="62a4a6b7a8b04da1ec8772eac68179bb26d62737"/>
+<project path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" name="platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" clone-depth="1" revision="9e42d0084ca256dd11d392fe9b4a39e2c166d3cd"/>
+<project path="prebuilts/bazel/linux-x86_64" name="platform/prebuilts/bazel/linux-x86_64" clone-depth="1" revision="8e5fbd4a700a3d00a810c8a890237eac04ca863b"/>
+<project path="prebuilts/clang/host/linux-x86" name="platform/prebuilts/clang/host/linux-x86" clone-depth="1" revision="849c7e048986d687d93da58b6bc77f87896996b7"/>
+<project path="prebuilts/build-tools" name="platform/prebuilts/build-tools" clone-depth="1" revision="d47c9b441de07f950e63f8a686266f56f58ea6c1"/>
+<project path="prebuilts/jdk/jdk11" name="platform/prebuilts/jdk/jdk11" clone-depth="1" revision="bacaa8f7ac8f1b3f1247a40dd2f8d2b6ddda1f4d"/>
+<project path="prebuilts/kernel-build-tools" name="kernel/prebuilts/build-tools" clone-depth="1" revision="a6313f09d63958d0a0f154b9f0d8d16047563040"/>
+<project path="prebuilts/ndk-r23" name="toolchain/prebuilts/ndk/r23" clone-depth="1" revision="19ac7e4eded12adb99d4f613490dde6dd0e72664"/>
+<project path="tools/mkbootimg" name="platform/system/tools/mkbootimg" revision="2680066d0844544b3e78d6022cd21321d31837c3"/>
+</manifest>


### PR DESCRIPTION
The Android R&D, which we are building should use the Android U-Boot. That one is built with the help of Bazel and repo. Repo is based on usage of the xml manifest.

This patch is introducing the default.xml repo manifest, which contains links to all required projects, which are needed to build Android U-Boot, including the u-boot fork from the xen-troops.